### PR TITLE
Parse body for common `Content-Type`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ createTestServer().then(server => {
 });
 ```
 
+The following `Content-Type` headers will be parsed and exposed via `req.body`:
+
+- JSON (`application/json`)
+- Text (`text/plain`)
+- URL-encoded form (`application/x-www-form-urlencoded`)
+- Buffer (`application/octet-stream`)
+
 `createTestServer()` has a Promise based API that pairs well with a modern asynchronous test runner such as [AVA](https://github.com/avajs/ava).
 
 You can create a separate server per test:

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/lukechilds/create-test-server",
   "dependencies": {
+    "body-parser": "^1.18.2",
     "create-cert": "^1.0.2",
     "express": "^4.15.3",
     "pify": "^3.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ const createTestServer = opts => createCert(opts && opts.certificate)
 		app.set('etag', false);
 		app.use(bodyParser.json({ type: 'application/json' }));
 		app.use(bodyParser.text({ type: 'text/plain' }));
+		app.use(bodyParser.urlencoded({ type: 'application/x-www-form-urlencoded' }));
 
 		app.caCert = keys.caCert;
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const createTestServer = opts => createCert(opts && opts.certificate)
 
 		app.set('etag', false);
 		app.use(bodyParser.json({ type: 'application/json' }));
+		app.use(bodyParser.text({ type: 'text/plain' }));
 
 		app.caCert = keys.caCert;
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const https = require('https');
 const express = require('express');
 const pify = require('pify');
 const createCert = require('create-cert');
+const bodyParser = require('body-parser');
 
 const createTestServer = opts => createCert(opts && opts.certificate)
 	.then(keys => {
@@ -23,6 +24,7 @@ const createTestServer = opts => createCert(opts && opts.certificate)
 		};
 
 		app.set('etag', false);
+		app.use(bodyParser.json({ type: 'application/json' }));
 
 		app.caCert = keys.caCert;
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const createTestServer = opts => createCert(opts && opts.certificate)
 		app.use(bodyParser.json({ type: 'application/json' }));
 		app.use(bodyParser.text({ type: 'text/plain' }));
 		app.use(bodyParser.urlencoded({ type: 'application/x-www-form-urlencoded' }));
+		app.use(bodyParser.raw({ type: 'application/octet-stream' }));
 
 		app.caCert = keys.caCert;
 

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -93,6 +93,21 @@ test('server automatically parses JSON request body', async t => {
 	});
 });
 
+test('server automatically parses text request body', async t => {
+	const server = await createTestServer();
+	const text = 'foo';
+
+	server.post('/echo', (req, res) => {
+		t.deepEqual(req.body, text);
+		res.end();
+	});
+
+	await got.post(server.url + '/echo', {
+		headers: { 'content-type': 'text/plain' },
+		body: text
+	});
+});
+
 test('opts.certificate is passed through to createCert()', async t => {
 	const server = await createTestServer({ certificate: 'foo.bar' });
 

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -78,6 +78,21 @@ test('server listens for SSL traffic', async t => {
 	t.is(body, 'bar');
 });
 
+test('server automatically parses JSON request body', async t => {
+	const server = await createTestServer();
+	const object = { foo: 'bar' };
+
+	server.post('/echo', (req, res) => {
+		t.deepEqual(req.body, object);
+		res.end();
+	});
+
+	await got.post(server.url + '/echo', {
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(object)
+	});
+});
+
 test('opts.certificate is passed through to createCert()', async t => {
 	const server = await createTestServer({ certificate: 'foo.bar' });
 

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -1,3 +1,4 @@
+import querystring from 'querystring';
 import test from 'ava';
 import got from 'got';
 import createTestServer from '../';
@@ -105,6 +106,21 @@ test('server automatically parses text request body', async t => {
 	await got.post(server.url + '/echo', {
 		headers: { 'content-type': 'text/plain' },
 		body: text
+	});
+});
+
+test('server automatically parses URL-encoded form request body', async t => {
+	const server = await createTestServer();
+	const object = { foo: 'bar' };
+
+	server.post('/echo', (req, res) => {
+		t.deepEqual(req.body, object);
+		res.end();
+	});
+
+	await got.post(server.url + '/echo', {
+		headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		body: querystring.stringify(object)
 	});
 });
 

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -124,6 +124,21 @@ test('server automatically parses URL-encoded form request body', async t => {
 	});
 });
 
+test('server automatically parses binary request body', async t => {
+	const server = await createTestServer();
+	const buffer = Buffer.from('foo');
+
+	server.post('/echo', (req, res) => {
+		t.deepEqual(req.body, buffer);
+		res.end();
+	});
+
+	await got.post(server.url + '/echo', {
+		headers: { 'content-type': 'application/octet-stream' },
+		body: buffer
+	});
+});
+
 test('opts.certificate is passed through to createCert()', async t => {
 	const server = await createTestServer({ certificate: 'foo.bar' });
 


### PR DESCRIPTION
Resolves #13 

Automatically parses the body as following types based on the `Content-Type` header:

- JSON (`application/json`)
- Text (`text/plain`)
- URL-encoded form (`application/x-www-form-urlencoded`)
- Buffer (`application/octet-stream`)

Exposed as `req.body`.