### PR TITLE
Allow options to be passed to `body-parser`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ Default: `undefined`
 
 SSL certificate options to be passed to [`createCert()`](https://github.com/lukechilds/create-cert).
 
+##### options.bodyParser
+
+Type: `object`
+Default: `undefined`
+
+Body parser options to be passed to [`body-parser`](https://github.com/expressjs/body-parser) methods.
+
 ### server
 
 Express instance resolved from `createTestServer()`

--- a/src/index.js
+++ b/src/index.js
@@ -24,11 +24,10 @@ const createTestServer = opts => createCert(opts && opts.certificate)
 		};
 
 		app.set('etag', false);
-		app.use(bodyParser.json({ type: 'application/json' }));
-		app.use(bodyParser.text({ type: 'text/plain' }));
-		app.use(bodyParser.urlencoded({ type: 'application/x-www-form-urlencoded', extended: true }));
-		app.use(bodyParser.raw({ type: 'application/octet-stream' }));
-
+		app.use(bodyParser.json(Object.assign({ type: 'application/json' }, opts && opts.bodyParser)));
+		app.use(bodyParser.text(Object.assign({ type: 'text/plain' }, opts && opts.bodyParser)));
+		app.use(bodyParser.urlencoded(Object.assign({ type: 'application/x-www-form-urlencoded', extended: true }, opts && opts.bodyParser)));
+		app.use(bodyParser.raw(Object.assign({ type: 'application/octet-stream' }, opts && opts.bodyParser)));
 		app.caCert = keys.caCert;
 
 		app.listen = () => Promise.all([

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -158,6 +158,11 @@ test('opts.bodyParser is passed through to bodyParser', async t => {
 	const bigServer = await createTestServer({ bodyParser: { limit: '200kb' } });
 	const buf = Buffer.alloc(150 * 1024);
 
+	// Custom error handler so we don't dump the stack trace in the test output
+	smallServer.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
+		res.status(500).end();
+	});
+
 	t.plan(3);
 
 	smallServer.post('/', (req, res) => {

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -153,6 +153,20 @@ test('opts.certificate is passed through to createCert()', async t => {
 	t.is(body, 'bar');
 });
 
+test('opts.bodyParser is passed through to bodyParser', async t => {
+	const server = await createTestServer({ bodyParser: { limit: '200kb' } });
+
+	server.post('/echo', (req, res) => {
+		t.pass(req.body.size > 100 * 1024);
+		res.end();
+	});
+
+	await got.post(server.url + '/echo', {
+		headers: { 'content-type': 'application/octet-stream' },
+		body: Buffer.alloc(101 * 1024)
+	});
+});
+
 test('support returning body directly', async t => {
 	const server = await createTestServer();
 

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -156,6 +156,7 @@ test('opts.certificate is passed through to createCert()', async t => {
 test('opts.bodyParser is passed through to bodyParser', async t => {
 	const smallServer = await createTestServer({ bodyParser: { limit: '100kb' } });
 	const bigServer = await createTestServer({ bodyParser: { limit: '200kb' } });
+	const buf = Buffer.alloc(150 * 1024);
 
 	smallServer.post('/echo', (req, res) => {
 		t.fail();
@@ -163,11 +164,9 @@ test('opts.bodyParser is passed through to bodyParser', async t => {
 	});
 
 	bigServer.post('/echo', (req, res) => {
-		t.pass(req.body.size > 100 * 1024);
+		t.true(req.body.length === buf.length);
 		res.end();
 	});
-
-	const buf = Buffer.alloc(150 * 1024);
 
 	await t.throws(got.post(smallServer.url + '/echo', {
 		headers: { 'content-type': 'application/octet-stream' },

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -173,10 +173,10 @@ test('opts.bodyParser is passed through to bodyParser', async t => {
 		body: buf
 	}));
 
-	await got.post(bigServer.url, {
+	await t.notThrows(got.post(bigServer.url, {
 		headers: { 'content-type': 'application/octet-stream' },
 		body: buf
-	});
+	}));
 });
 
 test('support returning body directly', async t => {

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -158,7 +158,7 @@ test('opts.bodyParser is passed through to bodyParser', async t => {
 	const bigServer = await createTestServer({ bodyParser: { limit: '200kb' } });
 
 	smallServer.post('/echo', (req, res) => {
-		t.pass(req.body.size > 100 * 1024);
+		t.fail();
 		res.end();
 	});
 

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -158,22 +158,22 @@ test('opts.bodyParser is passed through to bodyParser', async t => {
 	const bigServer = await createTestServer({ bodyParser: { limit: '200kb' } });
 	const buf = Buffer.alloc(150 * 1024);
 
-	smallServer.post('/echo', (req, res) => {
+	smallServer.post('/', (req, res) => {
 		t.fail();
 		res.end();
 	});
 
-	bigServer.post('/echo', (req, res) => {
+	bigServer.post('/', (req, res) => {
 		t.true(req.body.length === buf.length);
 		res.end();
 	});
 
-	await t.throws(got.post(smallServer.url + '/echo', {
+	await t.throws(got.post(smallServer.url, {
 		headers: { 'content-type': 'application/octet-stream' },
 		body: buf
 	}));
 
-	await got.post(bigServer.url + '/echo', {
+	await got.post(bigServer.url, {
 		headers: { 'content-type': 'application/octet-stream' },
 		body: buf
 	});

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -158,6 +158,8 @@ test('opts.bodyParser is passed through to bodyParser', async t => {
 	const bigServer = await createTestServer({ bodyParser: { limit: '200kb' } });
 	const buf = Buffer.alloc(150 * 1024);
 
+	t.plan(3);
+
 	smallServer.post('/', (req, res) => {
 		t.fail();
 		res.end();


### PR DESCRIPTION
Closes #21 maybe.  Would it be better to add a separate option for each `body-parser` method?