### PR TITLE
Added support to disable SSL server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,64 +7,86 @@ const pify = require('pify');
 const createCert = require('create-cert');
 const bodyParser = require('body-parser');
 
-const createTestServer = (opts = {}) => createCert(opts.certificate)
-	.then(keys => {
-		const server = express();
-		server.http = http.createServer(server);
+const createServer = (keys, opts) => {
+	const server = express();
+	server.http = http.createServer(server);
+
+	if (keys) {
 		server.https = https.createServer(keys, server);
 		server.caCert = keys.caCert;
+	}
 
-		server.set('etag', false);
+	server.set('etag', false);
 
-		if (opts.bodyParser !== false) {
-			server.use(bodyParser.json(Object.assign({ limit: '1mb', type: 'application/json' }, opts.bodyParser)));
-			server.use(bodyParser.text(Object.assign({ limit: '1mb', type: 'text/plain' }, opts.bodyParser)));
-			server.use(bodyParser.urlencoded(Object.assign({ limit: '1mb', type: 'application/x-www-form-urlencoded', extended: true }, opts.bodyParser)));
-			server.use(bodyParser.raw(Object.assign({ limit: '1mb', type: 'application/octet-stream' }, opts.bodyParser)));
-		}
+	if (opts.bodyParser !== false) {
+		server.use(bodyParser.json(Object.assign({ limit: '1mb', type: 'application/json' }, opts.bodyParser)));
+		server.use(bodyParser.text(Object.assign({ limit: '1mb', type: 'text/plain' }, opts.bodyParser)));
+		server.use(bodyParser.urlencoded(Object.assign({ limit: '1mb', type: 'application/x-www-form-urlencoded', extended: true }, opts.bodyParser)));
+		server.use(bodyParser.raw(Object.assign({ limit: '1mb', type: 'application/octet-stream' }, opts.bodyParser)));
+	}
 
-		const send = fn => (req, res, next) => {
-			const cb = typeof fn === 'function' ? fn(req, res, next) : fn;
+	const send = fn => (req, res, next) => {
+		const cb = typeof fn === 'function' ? fn(req, res, next) : fn;
 
-			Promise.resolve(cb).then(val => {
-				if (val) {
-					res.send(val);
-				}
-			});
-		};
-
-		const get = server.get.bind(server);
-		server.get = function () {
-			const [path, ...handlers] = [...arguments];
-
-			for (const handler of handlers) {
-				get(path, send(handler));
+		Promise.resolve(cb).then(val => {
+			if (val) {
+				res.send(val);
 			}
-		};
+		});
+	};
 
-		server.listen = () => Promise.all([
+	const get = server.get.bind(server);
+	server.get = function () {
+		const [path, ...handlers] = [...arguments];
+
+		for (const handler of handlers) {
+			get(path, send(handler));
+		}
+	};
+
+	server.listen = () => {
+		const promises = [
 			pify(server.http.listen.bind(server.http))().then(() => {
 				server.port = server.http.address().port;
 				server.url = `http://localhost:${server.port}`;
-			}),
-			pify(server.https.listen.bind(server.https))().then(() => {
-				server.sslPort = server.https.address().port;
-				server.sslUrl = `https://localhost:${server.sslPort}`;
 			})
-		]);
+		];
+		if (server.https) {
+			promises.push(
+				pify(server.https.listen.bind(server.https))().then(() => {
+					server.sslPort = server.https.address().port;
+					server.sslUrl = `https://localhost:${server.sslPort}`;
+				})
+			);
+		}
+		return Promise.all(promises);
+	};
 
-		server.close = () => Promise.all([
+	server.close = () => {
+		const promises = [
 			pify(server.http.close.bind(server.http))().then(() => {
 				server.port = undefined;
 				server.url = undefined;
-			}),
-			pify(server.https.close.bind(server.https))().then(() => {
-				server.sslPort = undefined;
-				server.sslUrl = undefined;
 			})
-		]);
+		];
+		if (server.https) {
+			promises.push(
+				pify(server.https.close.bind(server.https))().then(() => {
+					server.sslPort = undefined;
+					server.sslUrl = undefined;
+				})
+			);
+		}
+		return Promise.all(promises);
+	};
 
-		return server.listen().then(() => server);
-	});
+	return server.listen().then(() => server);
+};
 
-module.exports = createTestServer;
+module.exports = (opts = {}) => {
+	if (opts.certificate === false) {
+		return createServer(null, opts);
+	}
+
+	return createCert(opts.certificate).then(keys => createServer(keys, opts));
+};

--- a/test/create-test-server.js
+++ b/test/create-test-server.js
@@ -201,6 +201,16 @@ test('if opts.bodyParser is false body parsing middleware is disabled', async t 
 	});
 });
 
+test('if opts.certificate is false server wont create ssl', async t => {
+	const server = await createTestServer({
+		certificate: false
+	});
+
+	t.true(typeof server.sslPort === 'undefined');
+	t.true(typeof server.sslUrl === 'undefined');
+	t.true(typeof server.caCert === 'undefined');
+});
+
 test('support returning body directly', async t => {
 	const server = await createTestServer();
 


### PR DESCRIPTION
If **opts.certificate** type is boolean and is false the SSL server wont be created, this also ensure backward compatibility with previous versions where users does not specify the certificate option and its value is undefined.

If the user does not have openssl installed on it's machine without this changes the module is unusable.